### PR TITLE
[pthreads] Allow using CLOCK_BOOTTIME in pthread_condattr_setclock()

### DIFF
--- a/glibc-2.15-clock-boottime-pthread.patch
+++ b/glibc-2.15-clock-boottime-pthread.patch
@@ -1,0 +1,75 @@
+diff -Naur eglibc-2.15.orig/nptl/pthread_condattr_setclock.c eglibc-2.15/nptl/pthread_condattr_setclock.c
+--- eglibc-2.15.orig/nptl/pthread_condattr_setclock.c	2014-08-29 13:22:51.312395255 +0300
++++ eglibc-2.15/nptl/pthread_condattr_setclock.c	2014-08-29 13:39:27.368436371 +0300
+@@ -56,6 +56,29 @@
+ 	return EINVAL;
+ #endif
+     }
++  else if (clock_id == CLOCK_BOOTTIME)
++    {
++#ifndef __ASSUME_POSIX_TIMERS
++# ifdef __NR_clock_getres
++      /* Check whether the clock is available.  */
++      static int avail;
++
++      if (avail == 0)
++	{
++	  struct timespec ts;
++
++	  INTERNAL_SYSCALL_DECL (err);
++	  int val;
++	  val = INTERNAL_SYSCALL (clock_getres, err, 2, CLOCK_BOOTTIME, &ts);
++	  avail = INTERNAL_SYSCALL_ERROR_P (val, err) ? -1 : 1;
++	}
++
++      if (avail < 0)
++# endif
++	/* Not available.  */
++	return EINVAL;
++#endif
++    }
+   else if (clock_id != CLOCK_REALTIME)
+     /* If more clocks are allowed some day the storing of the clock ID
+        in the pthread_cond_t structure needs to be adjusted.  */
+diff -Naur eglibc-2.15.orig/nptl/sysdeps/unix/sysv/linux/internaltypes.h eglibc-2.15/nptl/sysdeps/unix/sysv/linux/internaltypes.h
+--- eglibc-2.15.orig/nptl/sysdeps/unix/sysv/linux/internaltypes.h	2014-08-29 13:22:51.304395255 +0300
++++ eglibc-2.15/nptl/sysdeps/unix/sysv/linux/internaltypes.h	2014-08-29 13:54:57.524474766 +0300
+@@ -79,8 +79,8 @@
+    of bits for other purposes.  COND_CLOCK_BITS is the number
+    of bits needed to represent the ID of the clock.  COND_NWAITERS_SHIFT
+    is the number of bits reserved for other purposes like the clock.  */
+-#define COND_CLOCK_BITS		1
+-#define COND_NWAITERS_SHIFT	1
++#define COND_CLOCK_BITS	        3
++#define COND_NWAITERS_SHIFT     3
+ 
+ 
+ /* Read-write lock variable attribute data structure.  */
+diff -Naur eglibc-2.15.orig/nptl/tst-cond11.c eglibc-2.15/nptl/tst-cond11.c
+--- eglibc-2.15.orig/nptl/tst-cond11.c	2014-08-29 13:22:51.304395255 +0300
++++ eglibc-2.15/nptl/tst-cond11.c	2014-08-29 13:53:32.440471254 +0300
+@@ -192,6 +192,10 @@
+   else
+ #  endif
+     res |= run_test (CLOCK_MONOTONIC);
++
++    if (clock_getres(CLOCK_BOOTTIME) == 0)
++      res |= run_test (CLOCK_BOOTTIME);
++
+ # else
+   puts ("_POSIX_MONOTONIC_CLOCK not defined");
+ # endif
+diff -Naur eglibc-2.15.orig/nptl/tst-cond23.c eglibc-2.15/nptl/tst-cond23.c
+--- eglibc-2.15.orig/nptl/tst-cond23.c	2014-08-29 13:22:51.308395255 +0300
++++ eglibc-2.15/nptl/tst-cond23.c	2014-08-29 13:52:37.380468981 +0300
+@@ -172,6 +172,10 @@
+   else
+ #  endif
+     res |= run_test (CLOCK_MONOTONIC);
++
++    if (clock_getres(CLOCK_BOOTTIME) == 0)
++      res |= run_test (CLOCK_BOOTTIME);
++
+ # else
+   puts ("_POSIX_MONOTONIC_CLOCK not defined");
+ # endif

--- a/glibc.spec
+++ b/glibc.spec
@@ -39,6 +39,7 @@ Patch13: eglibc-2.15-use-usrbin-localedef.patch
 Patch14: eglibc-2.15-fix-neon-libdl.patch
 Patch15: eglibc-2.15-shlib-make.patch
 Patch16: glibc-2.15-confstr-strdup.patch
+Patch17: glibc-2.15-clock-boottime-pthread.patch
 
 Provides: ldconfig
 # The dynamic linker supports DT_GNU_HASH
@@ -205,6 +206,7 @@ If unsure if you need this, don't install this package.
 %endif
 %patch15 -p1
 %patch16 -p2 -R 
+%patch17 -p1
 
 # Not well formatted locales --cvm
 sed -i "s|^localedata/locale-eo_EO.diff$||g" debian/patches/series


### PR DESCRIPTION
Signed-off-by: Hannu Mallat hannu.mallat@jollamobile.com

Allow CLOCK_BOOTTIME in pthread_condattr_setclock() so that glib2 can use CLOCK_BOOTTIME as thread timer while using it with g_get_monotonic_time().

Since the id for CLOCK_BOOTTIME is 7, had to resize the bit field holding clock id in the pthread_cond_t structure.
