### PR TITLE
Disable backtrace in __libc_message

### DIFF
--- a/eglibc-2.15-libc_message-nobacktrace.patch
+++ b/eglibc-2.15-libc_message-nobacktrace.patch
@@ -1,0 +1,11 @@
+--- eglibc-2.15.orig/sysdeps/unix/sysv/linux/libc_fatal.c	2011-05-15 15:22:50.000000000 +0300
++++ eglibc-2.15/sysdeps/unix/sysv/linux/libc_fatal.c	2014-11-26 15:38:35.410494136 +0200
+@@ -172,7 +172,7 @@
+ 
+   if (do_abort)
+     {
+-#if __OPTION_EGLIBC_BACKTRACE
++#if 0 /* __OPTION_EGLIBC_BACKTRACE */
+       if (do_abort > 1 && written)
+ 	{
+ 	  void *addrs[64];

--- a/glibc.changes
+++ b/glibc.changes
@@ -1,3 +1,6 @@
+* Wed Nov 26 2014 Slava Monich <slava.monichi@jolla.com> - 2.15
+- Disable backtrace in __libc_message
+
 * Wed Aug 29 2014 Pasi Sjöholm <pasi.sjoholm@jollamobile.com> - 2.15
 - Upgrade to 2.15-0ubuntu10.7
 

--- a/glibc.spec
+++ b/glibc.spec
@@ -39,6 +39,7 @@ Patch13: eglibc-2.15-use-usrbin-localedef.patch
 Patch14: eglibc-2.15-fix-neon-libdl.patch
 Patch15: eglibc-2.15-shlib-make.patch
 Patch16: glibc-2.15-confstr-strdup.patch
+Patch17: eglibc-2.15-libc_message-nobacktrace.patch
 
 Provides: ldconfig
 # The dynamic linker supports DT_GNU_HASH
@@ -205,6 +206,7 @@ If unsure if you need this, don't install this package.
 %endif
 %patch15 -p1
 %patch16 -p2 -R 
+%patch17 -p1
 
 # Not well formatted locales --cvm
 sed -i "s|^localedata/locale-eo_EO.diff$||g" debian/patches/series


### PR DESCRIPTION
It can result in a lockup and prevent the process from aborting in case of a catastrophic error.
