### PR TITLE
[security] Avoid infinite loop in nss_dns getnetbyname (CVE-2014-9402)

### DIFF
--- a/eglibc-2.15-avoid_infinite_loop.patch
+++ b/eglibc-2.15-avoid_infinite_loop.patch
@@ -1,0 +1,17 @@
+X-Git-Url: https://sourceware.org/git/gitweb.cgi?p=glibc.git;a=blobdiff_plain;f=resolv%2Fnss_dns%2Fdns-network.c;h=08cf0a6462ce9bb12ea04507041b5958a1ea24e3;hp=0a77c8bc4808a0974591f69845e6fec3b277d267;hb=11e3417af6e354f1942c68a271ae51e892b2814d;hpb=ae61fc7b33d9d99d2763c16de8275227dc9748ba
+
+diff --git a/resolv/nss_dns/dns-network.c b/resolv/nss_dns/dns-network.c
+index 0a77c8b..08cf0a6 100644
+--- a/resolv/nss_dns/dns-network.c
++++ b/resolv/nss_dns/dns-network.c
+@@ -398,8 +398,8 @@ getanswer_r (const querybuf *answer, int anslen, struct netent *result,
+ 
+ 	case BYNAME:
+ 	  {
+-	    char **ap = result->n_aliases++;
+-	    while (*ap != NULL)
++	    char **ap;
++	    for (ap = result->n_aliases; *ap != NULL; ++ap)
+ 	      {
+ 		/* Check each alias name for being of the forms:
+ 		   4.3.2.1.in-addr.arpa		= net 1.2.3.4

--- a/glibc.changes
+++ b/glibc.changes
@@ -1,3 +1,6 @@
+* Thu Jan 08 2015 Pasi Sjöholm <pasi.sjoholm@jollamobile.com> - 2.15
+- Avoid infinite loop in nss_dns getnetbyname (CVE-2014-9402)
+
 * Wed Dec 03 2014 Pasi Sjöholm <pasi.sjoholm@jollamobile.com> - 2.15
 - Upgrade to 2.15-0ubuntu10.9
 - Fix CVE-2012-6656, CVE-2014-6040 and CVE-2014-7817

--- a/glibc.spec
+++ b/glibc.spec
@@ -39,6 +39,7 @@ Patch14: eglibc-2.15-fix-neon-libdl.patch
 Patch15: eglibc-2.15-shlib-make.patch
 Patch16: glibc-2.15-confstr-strdup.patch
 Patch17: eglibc-2.15-libc_message-nobacktrace.patch
+Patch18: eglibc-2.15-avoid_infinite_loop.patch
 
 Provides: ldconfig
 # The dynamic linker supports DT_GNU_HASH
@@ -205,6 +206,7 @@ If unsure if you need this, don't install this package.
 %patch15 -p1
 %patch16 -p2 -R 
 %patch17 -p1
+%patch18 -p1
 
 # Not well formatted locales --cvm
 sed -i "s|^localedata/locale-eo_EO.diff$||g" debian/patches/series


### PR DESCRIPTION
Signed-off-by: Pasi Sjöholm <pasi.sjoholm@jollamobile.com>